### PR TITLE
Added filtering of emails and websites

### DIFF
--- a/Classes/ProfanityFilter.swift
+++ b/Classes/ProfanityFilter.swift
@@ -40,24 +40,24 @@ struct ProfanityDictionary {
 
 public struct ProfanityFilter {
     
-    static func censorString(_ string: String, filter: [FilterType]) -> String {
+    static func censorString(_ string: String, _ filter: [FilterType]) -> String {
         var cleanString = string
         
         if filter.contains(.profanity) {
             for word in string.profaneWords() {
                 let cleanWord = word.replaceWithAsterisks()
-                cleanString = cleanString.replacingOccurrences(of: word, with: cleanWord, options: [.   caseInsensitive], range: nil)
+                cleanString = cleanString.replacingOccurrences(of: word, with: cleanWord, options: [.caseInsensitive], range: nil)
             }
         }
         
         if filter.contains(.emails) || filter.contains(.websites) {
-            cleanString = self.blockOther(cleanString, filter: filter)
+            cleanString = self.blockOther(cleanString, filter)
         }
         
         return cleanString
     }
     
-    static func blockOther(_ string: String, filter: [FilterType]) -> String {
+    static func blockOther(_ string: String, _ filter: [FilterType]) -> String {
         var cleanString = string
         
         for words in string.components(separatedBy: " ") {
@@ -74,10 +74,10 @@ public struct ProfanityFilter {
 
 public extension String {
     
-    public func isValidWebsite() -> Bool {
-        let websiteRegEx = "[A-Z0-0a-z]+\\.[A-Za-z]{2,}"
+    func isValidWebsite() -> Bool {
+        let websiteRegEx = "[A-Z0-0a-z]+\\.[A-Za-z.,-=+]{2,}"
         
-        let websiteRegEx2 = "[A-Za-z]+\\.[A-Z0-0a-z]+\\.[A-Za-z]{2,}"
+        let websiteRegEx2 = "[A-Za-z]+\\.[A-Z0-0a-z]+\\.[A-Za-z.,-=+]{2,}"
         let webTest2 = NSPredicate(format: "SELF MATCHES %@", websiteRegEx2)
         let webTest = NSPredicate(format: "SELF MATCHES %@", websiteRegEx)
         
@@ -88,10 +88,9 @@ public extension String {
         }
     }
     
-    public func isValidEmail() -> Bool {
+    func isValidEmail() -> Bool {
         // print("validate calendar: \(testStr)")
-        let emailRegEx = "[A-Z0-9a-z._%+-]+[@][A-Za-z0-9.-]{2,}"
-        
+        let emailRegEx = "[A-Z0-9a-z._%+-]+[@][A-Za-z0-9.,-=+]{2,}"
         let emailTest = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
         return emailTest.evaluate(with: self)
     }
@@ -113,8 +112,13 @@ public extension String {
         return !profaneWords().isEmpty
     }
     
+    public func censored(_ filterDict: [String: Bool]) -> String {
+        let filters = getFiltersFromDict(filterDict)
+        return ProfanityFilter.censorString(self, filters)
+    }
+    
     public func censored(_ filter: [FilterType]) -> String {
-        return ProfanityFilter.censorString(self, filter: filter)
+        return ProfanityFilter.censorString(self, filter)
     }
     
     public mutating func censor(_ filter: [FilterType] = [.profanity]) {
@@ -127,24 +131,69 @@ public extension String {
 
 public extension NSString {
     
-    public func censored(_ filter: [FilterType] = [.profanity]) -> NSString {
-        return ProfanityFilter.censorString(self as String, filter: filter) as NSString
+    public func censored() -> NSString {
+       return censored([FilterType.profanity])
+    }
+    
+    public func censored(_ filterDict: [String: Bool]) -> NSString {
+        let filters = getFiltersFromDict(filterDict)
+        return ProfanityFilter.censorString(self as String, filters) as NSString
+    }
+    
+    public func censored(_ filter: [FilterType]) -> NSString {
+        return ProfanityFilter.censorString(self as String, filter) as NSString
     }
 }
 
 public extension NSMutableString {
     
-    public func censor(_ filter: [FilterType] = [.profanity]) {
-        setString(ProfanityFilter.censorString(self as String, filter: filter))
+    public func censor() {
+        censor([FilterType.profanity])
     }
+    
+    public func censor(_ filterDict: [String: Bool]) {
+        let filters = getFiltersFromDict(filterDict)
+        
+        setString(ProfanityFilter.censorString(self as String, filters))
+    }
+    
+    public func censor(_ filter: [FilterType]) {
+        setString(ProfanityFilter.censorString(self as String, filter))
+    }
+    
 }
 
-public enum FilterType { case profanity, websites, emails }
+public enum FilterType: Int { case profanity = 0, websites, emails }
 
+public func getFiltersFromDict(_ filterDict: [String: Bool]) -> [FilterType] {
+    var types = [FilterType]()
+    for (key,value) in filterDict {
+        if key == "profanity" && value {
+            types.append(.profanity)
+        } else if key == "emails" && value {
+            types.append(.emails)
+        } else if key == "websites" && value {
+            types.append(.websites)
+        }
+    }
+    return types
+}
 
 public extension NSAttributedString {
     
-    public func censored(_ filter: [FilterType] = [.profanity]) -> NSAttributedString {
+    
+    public func censored() -> NSAttributedString {
+        return censored([FilterType.profanity])
+        
+    }
+    
+    
+    public func censored(_ filterDict: [String: Bool]) -> NSAttributedString {
+       let filters = getFiltersFromDict(filterDict)
+        return censored(filters)
+    }
+    
+    public func censored(_ filter: [FilterType]) -> NSAttributedString {
         
         let profaneWords = string.profaneWords()
         var cleanString = NSMutableAttributedString(attributedString: self)

--- a/GoshDarnIt/GoshDarnItObjCTests/GoshDarnItObjCTests.m
+++ b/GoshDarnIt/GoshDarnItObjCTests/GoshDarnItObjCTests.m
@@ -31,6 +31,7 @@
     NSString *input = @"Fuck it";
     NSString *censored = [input censored];
     
+    
     XCTAssertEqualObjects(@"**** it", censored);
 }
 
@@ -40,6 +41,60 @@
     [input censor];
     
     XCTAssertEqualObjects(@"**** it", input);
+}
+
+- (void)testEmailFilter {
+    
+    NSString *input = @"johnSmith@gmail.com";
+    NSDictionary *censorDict = @{ @"emails": @TRUE };
+    NSString *censored = [input censored: censorDict];
+    
+    XCTAssertEqualObjects(@"*******************", censored);
+}
+
+- (void)testWebsiteFilter {
+    NSString *input = @"www.google.ca";
+    NSDictionary *censorDict = @{ @"websites": @TRUE };
+    NSString *censored = [input censored:censorDict];
+   
+    XCTAssertEqualObjects(@"*************", censored);
+}
+
+- (void)testNSMutableStringForEmailsFilter {
+    NSMutableString *input = [NSMutableString stringWithString:@"johnSmith@gmail.com"];
+    NSDictionary *censorDict = @{ @"emails": @TRUE };
+    [input censor:censorDict];
+    XCTAssertEqualObjects(@"*******************", input);
+}
+
+- (void)testNSMutableStringForWebsitesFilter {
+    NSMutableString *input = [NSMutableString stringWithString:@"www.google.ca"];
+    NSDictionary *censorDict = @{ @"websites": @TRUE };
+    [input censor:censorDict];
+    XCTAssertEqualObjects(@"*************", input);
+}
+
+- (void)testNSMutableStringForAllFilters {
+    NSMutableString *input = [NSMutableString stringWithString:@"Fuck this www.google.ca email me at johnSmith@gmail.com"];
+    NSDictionary *censorDict = @{
+                                 @"websites": @TRUE,
+                                 @"profanity": @TRUE,
+                                 @"emails": @TRUE
+                                 };
+    [input censor:censorDict];
+    NSLog(@"%@",input);
+    XCTAssertEqualObjects(@"**** this ************* email me at *******************", input);
+}
+
+- (void)testAllFilters {
+    NSString *input = @"Fuck this www.google.ca email me at johnSmith@gmail.com";
+    NSDictionary *censorDict = @{
+                                 @"websites": @TRUE,
+                                 @"profanity": @TRUE,
+                                 @"emails": @TRUE
+                                 };
+    NSString *censored = [input censored: censorDict];
+    XCTAssertEqualObjects(@"**** this ************* email me at *******************", censored);
 }
 
 @end

--- a/GoshDarnIt/GoshDarnItTests/GoshDarnItTests.swift
+++ b/GoshDarnIt/GoshDarnItTests/GoshDarnItTests.swift
@@ -97,4 +97,19 @@ class GoshDarnItTests: XCTestCase {
         let input = "The first line\nshit\nand the third"
         XCTAssertEqual("The first line\n****\nand the third", input.censored([FilterType.profanity]))
     }
+    
+    func testEmailFilter() {
+       let input = "johnSmith@gmail.com"
+        XCTAssertEqual("*******************", input.censored([FilterType.emails]))
+    }
+    
+    func testWebsiteFilter() {
+        let input = "www.google.ca"
+        XCTAssertEqual("*************", input.censored([FilterType.websites]))
+    }
+    
+    func testAllFilters() {
+        let input = "Fuck this www.google.ca email me at johnSmith@gmail.com"
+        XCTAssertEqual("**** this ************* email me at *******************", input.censored([FilterType.emails, .profanity, .websites]))
+    }
 }

--- a/GoshDarnIt/GoshDarnItTests/GoshDarnItTests.swift
+++ b/GoshDarnIt/GoshDarnItTests/GoshDarnItTests.swift
@@ -26,7 +26,7 @@ class GoshDarnItTests: XCTestCase {
         
         let input = "Fuck it"
         
-        let censored = input.censored()
+        let censored = input.censored([FilterType.profanity])
         
         XCTAssertEqual("**** it", censored)
     }
@@ -34,8 +34,7 @@ class GoshDarnItTests: XCTestCase {
     func testStringCensor() {
         
         var input = "Fuck it"
-        
-        input.censor()
+        input.censor([FilterType.profanity])
         
         XCTAssertEqual("**** it", input)
     }
@@ -44,7 +43,7 @@ class GoshDarnItTests: XCTestCase {
         
         let input: NSString = "Fuck it"
         
-        let censored = input.censored()
+        let censored = input.censored([FilterType.profanity])
         
         XCTAssertEqual("**** it", censored)
     }
@@ -52,7 +51,7 @@ class GoshDarnItTests: XCTestCase {
     func testNSMutableString() {
         
         let input: NSMutableString = "Fuck it"
-        input.censor()
+        input.censor([FilterType.profanity])
         
         XCTAssertEqual("**** it", input)
     }
@@ -63,39 +62,39 @@ class GoshDarnItTests: XCTestCase {
     func testSingle() {
         let input = "crap"
         
-        XCTAssertEqual("****", input.censored())
+        XCTAssertEqual("****", input.censored([FilterType.profanity]))
     }
     
     func testCasing() {
         let input = "cRap"
         
-        XCTAssertEqual("****", input.censored())
+        XCTAssertEqual("****", input.censored([FilterType.profanity]))
     }
     
     func testAllowSubstring() {
         let input = "I buy crepes at the crapery"
-        XCTAssertEqual("I buy crepes at the crapery", input.censored())
+        XCTAssertEqual("I buy crepes at the crapery", input.censored([FilterType.profanity]))
     }
     
     func testMultiple() {
         
         let input = "Fucking wanker"
         
-        XCTAssertEqual("******* ******", input.censored())
+        XCTAssertEqual("******* ******", input.censored([FilterType.profanity]))
     }
     
     func testPunctuation() {
         let input = "This is shit, this testing."
-        XCTAssertEqual("This is ****, this testing.", input.censored())
+        XCTAssertEqual("This is ****, this testing.", input.censored([FilterType.profanity]))
     }
     
     func testPunctuationInString() {
         let input = "This is shit-ass-fuck"
-        XCTAssertEqual("This is ****-***-****", input.censored())
+        XCTAssertEqual("This is ****-***-****", input.censored([FilterType.profanity]))
     }
     
     func testMultipleLines() {
         let input = "The first line\nshit\nand the third"
-        XCTAssertEqual("The first line\n****\nand the third", input.censored())
+        XCTAssertEqual("The first line\n****\nand the third", input.censored([FilterType.profanity]))
     }
 }


### PR DESCRIPTION
Now user can choose to filter only profanity via previous syntax or filter additional content such as website and/or emails. 